### PR TITLE
Simplify coveralls configuration in GitHub workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,18 +64,6 @@ jobs:
         if: "matrix.python-version != '2.7' && matrix.python-version != 'pypy2'"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_PARALLEL: true
-
-  finish:
-    name: Tell Coveralls that we're finished running all parallel jobs
-    needs: build
-    runs-on: ubuntu-latest
-    container: python:3-slim
-    steps:
-      - run: pip3 install -U coveralls
-      - run: coveralls --finish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   lint:
     name: ${{ matrix.toxenv }}


### PR DESCRIPTION
I think I misunderstood https://coveralls-python.readthedocs.io/en/latest/usage/configuration.html#github-actions-gotcha and this is not needed when you simply test the same code under multiple Python versions.