### PR TITLE
use repository's configured default branch instead of assuming master

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog
 1.10.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- When determining if a repository is dirty, use the repository's
+  configured default branch from GitHub instead of assuming that the
+  default is "master".
 
 
 1.10.0 (2021-04-10)

--- a/README.rst
+++ b/README.rst
@@ -63,8 +63,8 @@ What it does:
   - unknown files in the tree (in --verbose mode only)
   - staged but not committed changes
   - uncommitted (and unstaged changes)
-  - non-master branch checked out
-  - committed changes that haven't been pushed to master
+  - non-default branch checked out
+  - committed changes that haven't been pushed to default branch
   - remote URL pointing to an unexpected location (in --verbose mode only)
 
 You can ask it to not change any files on disk and just look for pending

--- a/ghcloneall.py
+++ b/ghcloneall.py
@@ -347,11 +347,12 @@ class Progress(object):
 
 
 class Repo(object):
-    def __init__(self, name, clone_url, alt_urls=()):
+    def __init__(self, name, clone_url, alt_urls=(), default_branch='master'):
         self.name = name
         self.clone_url = clone_url
         self.urls = {clone_url}
         self.urls.update(alt_urls)
+        self.default_branch = default_branch
 
     def __repr__(self):
         return 'Repo({!r}, {!r}, {{{}}})'.format(
@@ -374,7 +375,8 @@ class Repo(object):
         # use repo['git_url'] for anonymous checkouts, but they're slower
         # (at least as long as you use SSH connection multiplexing)
         clone_url = repo['ssh_url']
-        return cls(repo['name'], clone_url, (repo['clone_url'],))
+        return cls(repo['name'], clone_url, (repo['clone_url'],),
+                   repo['default_branch'])
 
     @classmethod
     def from_gist(cls, gist):
@@ -618,8 +620,9 @@ class RepoTask(object):
             self.progress_item.update(' (local commits)')
             self.dirty = True
         branch = self.get_current_branch(dir)
-        if branch != 'master':
-            self.progress_item.update(' (not on master)')
+        if branch != repo.default_branch:
+            self.progress_item.update(' (not on {})'.format(
+                repo.default_branch))
             if self.options.verbose >= 2:
                 self.progress_item.extra_info('branch: {}'.format(branch))
             self.dirty = True


### PR DESCRIPTION
GitHub allows repositories to have a configured default branch other
than 'master'. When reporting that a local copy of a repo may be
dirty, use the default branch reported by the API, instead of assuming
a static value of 'master'.