### PR TITLE
clean up private argument handling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,7 @@ Other command-line options::
                             (default)
       --include-archived    include archived repositories
       --exclude-archived    exclude archived repositories (default)
-      --include-private     include private repositories, requires a github token (default)
+      --include-private     include private repositories (default when a github token is provided)
       --exclude-private     exclude private repositories
       --include-disabled    include disabled repositories (default)
       --exclude-disabled    exclude disabled repositories

--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,7 @@ Other command-line options::
                             (default)
       --include-archived    include archived repositories
       --exclude-archived    exclude archived repositories (default)
-      --include-private     include private repositories (default)
+      --include-private     include private repositories, requires a github token (default)
       --exclude-private     exclude private repositories
       --include-disabled    include disabled repositories (default)
       --exclude-disabled    exclude disabled repositories
@@ -140,6 +140,7 @@ should look like this::
     # gists = False
     # include_forks = False
     # include_archived = False
+    # Listing private repositories requires a valid github_token
     # include_private = True
     # include_disabled = True
 

--- a/ghcloneall.py
+++ b/ghcloneall.py
@@ -931,7 +931,7 @@ def _main():
         return
 
     if args.include_private is None:
-        args.include_private = True
+        args.include_private = bool(args.github_token)
     if args.include_disabled is None:
         args.include_disabled = True
 

--- a/ghcloneall.py
+++ b/ghcloneall.py
@@ -930,6 +930,9 @@ def _main():
                     CONFIG_FILE))
         return
 
+    if args.include_private and not args.github_token:
+        print('Warning: Listing private repositories requires a GitHub token')
+        args.include_private = False
     if args.include_private is None:
         args.include_private = bool(args.github_token)
     if args.include_disabled is None:

--- a/ghcloneall.py
+++ b/ghcloneall.py
@@ -931,7 +931,8 @@ def _main():
         return
 
     if args.include_private and not args.github_token:
-        print('Warning: Listing private repositories requires a GitHub token')
+        print('Warning: Listing private repositories requires a GitHub token',
+              file=sys.stderr)
         args.include_private = False
     if args.include_private is None:
         args.include_private = bool(args.github_token)

--- a/ghcloneall.py
+++ b/ghcloneall.py
@@ -824,7 +824,8 @@ def _main():
         help='exclude archived repositories (default)')
     parser.add_argument(
         '--include-private', action='store_true', default=None,
-        help='include private repositories (default)')
+        help=('include private repositories '
+              '(default when a github token is provided)'))
     parser.add_argument(
         '--exclude-private', action='store_false', dest='include_private',
         help='exclude private repositories')

--- a/tests.py
+++ b/tests.py
@@ -1464,10 +1464,13 @@ def test_main_run_private_without_token(monkeypatch, mock_requests_get,
         ],
     ))
     ghcloneall.main()
-    assert show_ansi_result(capsys.readouterr().out) == (
-        'Warning: Listing private repositories requires a GitHub token\n'
+    captured = capsys.readouterr()
+    assert show_ansi_result(captured.out) == (
         '+ ghcloneall (new)\n'
         '1 repositories: 0 updated, 1 new, 0 dirty.'
+    )
+    assert captured.err == (
+        'Warning: Listing private repositories requires a GitHub token\n'
     )
 
 

--- a/tests.py
+++ b/tests.py
@@ -1418,6 +1418,29 @@ def test_main_run(monkeypatch, mock_requests_get, capsys):
     ghcloneall.main()
     assert show_ansi_result(capsys.readouterr().out) == (
         '+ ghcloneall (new)\n'
+        '1 repositories: 0 updated, 1 new, 0 dirty.'
+    )
+
+
+def test_main_run_with_token(monkeypatch, mock_requests_get, capsys):
+    monkeypatch.setattr(sys, 'argv', [
+        'ghcloneall', '--user', 'mgedmin', '--concurrency=1',
+        '--github-token', 'fake-token',
+    ])
+    mock_requests_get.update(mock_multi_page_api_responses(
+        url='https://api.github.com/user/repos?affiliation=owner',
+        pages=[
+            [
+                repo('ghcloneall'),
+                repo('experiment', archived=True),
+                repo('typo-fix', fork=True),
+                repo('xyzzy', private=True, disabled=True),
+            ],
+        ],
+    ))
+    ghcloneall.main()
+    assert show_ansi_result(capsys.readouterr().out) == (
+        '+ ghcloneall (new)\n'
         '+ xyzzy (new)\n'
         '2 repositories: 0 updated, 2 new, 0 dirty.'
     )

--- a/tests.py
+++ b/tests.py
@@ -1446,6 +1446,31 @@ def test_main_run_with_token(monkeypatch, mock_requests_get, capsys):
     )
 
 
+def test_main_run_private_without_token(monkeypatch, mock_requests_get,
+                                        capsys):
+    monkeypatch.setattr(sys, 'argv', [
+        'ghcloneall', '--user', 'mgedmin', '--concurrency=1',
+        '--include-private',
+    ])
+    mock_requests_get.update(mock_multi_page_api_responses(
+        url='https://api.github.com/users/mgedmin/repos',
+        pages=[
+            [
+                repo('ghcloneall'),
+                repo('experiment', archived=True),
+                repo('typo-fix', fork=True),
+                repo('xyzzy', private=True, disabled=True),
+            ],
+        ],
+    ))
+    ghcloneall.main()
+    assert show_ansi_result(capsys.readouterr().out) == (
+        'Warning: Listing private repositories requires a GitHub token\n'
+        '+ ghcloneall (new)\n'
+        '1 repositories: 0 updated, 1 new, 0 dirty.'
+    )
+
+
 def test_main_run_start_from(monkeypatch, mock_requests_get, capsys):
     monkeypatch.setattr(sys, 'argv', [
         'ghcloneall', '--user', 'mgedmin', '--start-from', 'x',


### PR DESCRIPTION
* warn if --include-private is used explicitly without --github-token
* default include_private based on whether there is a github_token
* document that --include-private requires a github token